### PR TITLE
Cmake rewrite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,9 @@ if(NOT TARGET PTHASH)
       target_compile_options(PTHASH INTERFACE -fsanitize=address -fno-omit-frame-pointer)
     endif()
   endif()
+
+  add_subdirectory(external/essentials)
+  target_link_libraries(PTHASH INTERFACE ESSENTIALS)
 endif()
 
 # Only add benchmarks and tests when compiling PTHash itself, not when added as a dependency

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,61 +1,67 @@
 cmake_minimum_required(VERSION 3.5)
 project(PTHASH)
 
-set(CMAKE_CXX_STANDARD 17)
 if (NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE "Release")
+  set(CMAKE_BUILD_TYPE "Release")
 endif ()
-
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-endif()
-
 MESSAGE(STATUS "CMAKE_BUILD_TYPE: " ${CMAKE_BUILD_TYPE})
 
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+if(NOT TARGET PTHASH)
+  add_library(PTHASH INTERFACE)
+  target_include_directories(PTHASH INTERFACE include)
 
-MESSAGE(STATUS "Compiling for processor: " ${CMAKE_HOST_SYSTEM_PROCESSOR})
-
-if (UNIX AND (CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64"))
-  MESSAGE(STATUS "Compiling with flags: -march=native -mbmi2 -msse4.2")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
-  # Flags for PTHash:
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mbmi2 -msse4.2") # for hardware popcount and pdep
-endif()
-
-if (PTHASH_ENABLE_ALL_ENCODERS)
-  MESSAGE(STATUS "compiling with all encoders")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DPTHASH_ENABLE_ALL_ENCODERS")
-endif()
-
-if (PTHASH_ENABLE_LARGE_BUCKET_ID_TYPE)
-  MESSAGE(STATUS "bucket_id_type is uint64_t")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DPTHASH_ENABLE_LARGE_BUCKET_ID_TYPE")
-endif()
-
-if (UNIX)
-
-  MESSAGE(STATUS "Compiling with flags: -std=c++17 -O3 -ggdb -pthread -Wall -Wextra -Wno-missing-braces -Wno-unknown-attributes -Wno-unused-function")
-
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ggdb")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-missing-braces -Wno-unknown-attributes -Wno-unused-function")
-
-  if (PTHASH_USE_SANITIZERS)
-    MESSAGE(STATUS "Using sanitizers. Compiling with flags: -fsanitize=address -fno-omit-frame-pointer")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
+  target_compile_features(PTHASH INTERFACE cxx_std_17)
+  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    target_compile_options(PTHASH INTERFACE -stdlib=libc++)
   endif()
 
+  MESSAGE(STATUS "Compiling for processor: " ${CMAKE_HOST_SYSTEM_PROCESSOR})
+
+  if (UNIX AND (CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64"))
+    MESSAGE(STATUS "Compiling with flags: -march=native -mbmi2 -msse4.2")
+    target_compile_options(PTHASH INTERFACE -march=native)
+    # Flags for PTHASH:
+    target_compile_options(PTHASH INTERFACE -mbmi2 -msse4.2) # for hardware popcount and pdep
+  endif()
+
+  if (PTHASH_ENABLE_ALL_ENCODERS)
+    MESSAGE(STATUS "compiling with all encoders")
+    target_compile_options(PTHASH INTERFACE -DPTHASH_ENABLE_ALL_ENCODERS)
+  endif()
+
+  if (PTHASH_ENABLE_LARGE_BUCKET_ID_TYPE)
+    MESSAGE(STATUS "bucket_id_type is uint64_t")
+    target_compile_options(PTHASH INTERFACE -DPTHASH_ENABLE_LARGE_BUCKET_ID_TYPE)
+  endif()
+
+  if (UNIX)
+    MESSAGE(STATUS "Compiling with flags: -std=c++17 -ggdb -pthread -Wall -Wextra -Wno-missing-braces -Wno-unknown-attributes -Wno-unused-function")
+
+    target_compile_options(PTHASH INTERFACE -std=c++17)
+    target_compile_options(PTHASH INTERFACE -pthread)
+    target_compile_options(PTHASH INTERFACE -ggdb)
+    target_compile_options(PTHASH INTERFACE -Wall -Wextra -Wno-missing-braces -Wno-unknown-attributes -Wno-unused-function)
+
+    if (PTHASH_USE_SANITIZERS)
+      MESSAGE(STATUS "Using sanitizers. Compiling with flags: -fsanitize=address -fno-omit-frame-pointer")
+      target_compile_options(PTHASH INTERFACE -fsanitize=address -fno-omit-frame-pointer)
+    endif()
+  endif()
 endif()
 
-add_executable(build src/build.cpp)
-add_executable(example src/example.cpp)
+# Only add benchmarks and tests when compiling PTHash itself, not when added as a dependency
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+  add_executable(build src/build.cpp)
+  target_link_libraries(build PRIVATE PTHASH)
+  add_executable(example src/example.cpp)
+  target_link_libraries(example PRIVATE PTHASH)
 
-file(GLOB TEST_SOURCES test/test_*.cpp)
-foreach(TEST_SRC ${TEST_SOURCES})
-  get_filename_component (TEST_SRC_NAME ${TEST_SRC} NAME_WE) # without extension
-  add_executable(${TEST_SRC_NAME} ${TEST_SRC})
-  add_test(${TEST_SRC_NAME} ${TEST_SRC_NAME})
-endforeach(TEST_SRC)
+  file(GLOB TEST_SOURCES test/test_*.cpp)
+  foreach(TEST_SRC ${TEST_SOURCES})
+    get_filename_component (TEST_SRC_NAME ${TEST_SRC} NAME_WE) # without extension
+    add_executable(${TEST_SRC_NAME} ${TEST_SRC})
+    add_test(${TEST_SRC_NAME} ${TEST_SRC_NAME})
+    target_link_libraries(${TEST_SRC_NAME} PRIVATE PTHASH)
+  endforeach(TEST_SRC)
+endif()

--- a/include/builders/search.hpp
+++ b/include/builders/search.hpp
@@ -4,7 +4,7 @@
 #include <sstream>  // for stringbuf
 #include <atomic>   // for std::atomic
 #include <vector>
-#include "../../external/essentials/include/essentials.hpp"
+#include <essentials.hpp>
 
 #include "util.hpp"
 #include "../encoders/bit_vector.hpp"

--- a/include/encoders/bit_vector.hpp
+++ b/include/encoders/bit_vector.hpp
@@ -5,7 +5,7 @@
 
 #include "util.hpp"
 
-#include "../../external/essentials/include/essentials.hpp"
+#include <essentials.hpp>
 
 namespace pthash {
 

--- a/include/encoders/compact_vector.hpp
+++ b/include/encoders/compact_vector.hpp
@@ -3,7 +3,7 @@
 #include <vector>
 #include <cmath>
 
-#include "../../external/essentials/include/essentials.hpp"
+#include <essentials.hpp>
 
 namespace pthash {
 

--- a/include/utils/util.hpp
+++ b/include/utils/util.hpp
@@ -3,7 +3,7 @@
 #include <chrono>
 #include <string>
 
-#include "../../external/essentials/include/essentials.hpp"
+#include <essentials.hpp>
 #include "../../external/fastmod/fastmod.h"
 
 #define PTHASH_LIKELY(expr) __builtin_expect((bool)(expr), true)

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -10,7 +10,7 @@
 #include <vector>
 
 #include "../include/utils/util.hpp"
-#include "../external/essentials/include/essentials.hpp"
+#include <essentials.hpp>
 
 namespace pthash {
 


### PR DESCRIPTION
This PR contains two commits.

- The first commit turns the cmake setup of PTHash into something that can be used as a library more easily. For this, it sets the compiler options on the PTHash target, instead of setting them on all targets using the library (`target_compile_options` instead of `CMAKE_CXX_FLAGS`). It also removes the hard-coded `-o3` flag, which would otherwise force library users to always have optimization enabled, even if they do a debug build. `-o3` is added automatically when selecting the `Release` cmake build type.
- The second commit switches to including the `essentials` library through cmake instead of hardcoded paths. That makes it possible to include PTHash together with another project that also uses the `essentials` library.

Fixes https://github.com/jermp/essentials/issues/6