### PR TITLE
Do not specify c++ version again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,6 @@ if(NOT TARGET PTHASH)
   if (UNIX)
     MESSAGE(STATUS "Compiling with flags: -std=c++17 -ggdb -pthread -Wall -Wextra -Wno-missing-braces -Wno-unknown-attributes -Wno-unused-function")
 
-    target_compile_options(PTHASH INTERFACE -std=c++17)
     target_compile_options(PTHASH INTERFACE -pthread)
     target_compile_options(PTHASH INTERFACE -ggdb)
     target_compile_options(PTHASH INTERFACE -Wall -Wextra -Wno-missing-braces -Wno-unknown-attributes -Wno-unused-function)


### PR DESCRIPTION
The cpp version is already handled in `target_compile_features`. No need to specify it again as compiler option in `target_compile_options`.

When using `target_compile_options` and including PTHash in a project that needs c++20, this otherwise breaks c++20 support for the parent project.