### PR TITLE
Further CPU and GPU impementation alingment

### DIFF
--- a/include/builders/internal_memory_builder_partitioned_phf.hpp
+++ b/include/builders/internal_memory_builder_partitioned_phf.hpp
@@ -35,6 +35,7 @@ struct internal_memory_builder_partitioned_phf {
         m_bucketer.init(num_partitions);
         m_offsets.resize(num_partitions + 1);
         m_builders.resize(num_partitions);
+        m_num_buckets_per_partition = compute_num_buckets(config.avg_partition_size, config.lambda);
 
         std::vector<std::vector<typename hasher_type::hash_type>> partitions(num_partitions);
         for (auto& partition : partitions) partition.reserve(1.1 * config.avg_partition_size);
@@ -72,12 +73,7 @@ struct internal_memory_builder_partitioned_phf {
 
         auto partition_config = config;
         partition_config.seed = m_seed;
-
-        const uint64_t num_buckets_single_phf = compute_num_buckets(num_keys, config.lambda);
-        const uint64_t num_buckets_per_partition =
-            std::ceil(static_cast<double>(num_buckets_single_phf) / num_partitions);
-        m_num_buckets_per_partition = num_buckets_per_partition;
-        partition_config.num_buckets = num_buckets_per_partition;
+        partition_config.num_buckets = m_num_buckets_per_partition;
         if (config.verbose_output) {
             std::cout << "num_buckets_per_partition = " << partition_config.num_buckets
                       << std::endl;

--- a/include/dense_partitioned_phf.hpp
+++ b/include/dense_partitioned_phf.hpp
@@ -117,7 +117,8 @@ struct dense_partitioned_phf {
         visitor.visit(m_bucketer);
         visitor.visit(m_pilots);
         visitor.visit(m_offsets);
-        visitor.visit(m_free_slots);
+        if(needsFreeArray)
+            visitor.visit(m_free_slots);
     }
 
 private:

--- a/include/dense_partitioned_phf.hpp
+++ b/include/dense_partitioned_phf.hpp
@@ -21,7 +21,7 @@ struct dense_partitioned_phf {
     }
 
     template <typename Builder>
-    double build(Builder& builder, build_configuration const& /* config */)  //
+    double build(Builder& builder, build_configuration const&  config)  //
     {
         auto start = clock_type::now();
 
@@ -40,7 +40,7 @@ struct dense_partitioned_phf {
         const uint64_t increment = m_table_size / num_partitions;
         m_offsets.encode(offsets.begin(), offsets.size(), increment);
         m_pilots.encode(builder.interleaving_pilots_iterator_begin(), num_partitions,
-                        num_buckets_per_partition);
+                        num_buckets_per_partition, config.num_threads);
         if constexpr (needsFreeArray) {
             assert(builder.free_slots().size() == m_table_size - m_num_keys);
             m_free_slots.encode(builder.free_slots().data(), m_table_size - m_num_keys);

--- a/include/dense_partitioned_phf.hpp
+++ b/include/dense_partitioned_phf.hpp
@@ -93,7 +93,7 @@ struct dense_partitioned_phf {
     }
 
     size_t num_bits_for_mapper() const {
-        return m_offsets.num_bits() + (needsFreeArray ? m_free_slots.num_bits() : 0);
+        return m_partitioner.num_bits() + m_bucketer.num_bits()  + m_offsets.num_bits() + (needsFreeArray ? m_free_slots.num_bits() : 0);
     }
 
     size_t num_bits() const {

--- a/include/dense_partitioned_phf.hpp
+++ b/include/dense_partitioned_phf.hpp
@@ -93,8 +93,7 @@ struct dense_partitioned_phf {
     }
 
     size_t num_bits_for_mapper() const {
-        return m_partitioner.num_bits() + m_bucketer.num_bits() + m_offsets.num_bits() +
-               m_free_slots.num_bits();
+        return m_offsets.num_bits() + (needsFreeArray ? m_free_slots.num_bits() : 0);
     }
 
     size_t num_bits() const {


### PR DESCRIPTION
Aligned calculation  of bucket count per partition to GPU
Removed bucketer from space consumption (in my opinion we do not need to count anything towards space consumption that does not depend on the input keys themselves.)

GPU and CPU implementation now have same (max diff 0.004 bits per key) space consumption for same configuration 