### PR TITLE
Fix partitioned_phf name in example.cpp

### DIFF
--- a/src/example.cpp
+++ b/src/example.cpp
@@ -30,7 +30,8 @@ int main() {
     // config.num_partitions = 50;
     // config.num_threads = 4;
     // typedef partitioned_phf<murmurhash2_64,        // base hasher
-    //                         dictionary_dictionary  // encoder type
+    //                         dictionary_dictionary, // encoder type
+    //                         true
     //                         >
     //     pthash_type;
 

--- a/src/example.cpp
+++ b/src/example.cpp
@@ -29,9 +29,9 @@ int main() {
 
     // config.num_partitions = 50;
     // config.num_threads = 4;
-    // typedef partitioned_mphf<murmurhash2_64,        // base hasher
-    //                          dictionary_dictionary  // encoder type
-    //                          >
+    // typedef partitioned_phf<murmurhash2_64,        // base hasher
+    //                         dictionary_dictionary  // encoder type
+    //                         >
     //     pthash_type;
 
     pthash_type f;


### PR DESCRIPTION
7aecc467398782c745fbd67aadc5f95ce285c570 changed the class name, but did not update this commented-out code.