### PR TITLE
Add getters for m_seed in partitioned_phf and single_phf

### DIFF
--- a/include/partitioned_phf.hpp
+++ b/include/partitioned_phf.hpp
@@ -122,6 +122,10 @@ public:
         return m_table_size;
     }
 
+    inline uint64_t seed() const {
+        return m_seed;
+    }
+
     template <typename Visitor>
     void visit(Visitor& visitor) {
         visitor.visit(m_seed);

--- a/include/single_phf.hpp
+++ b/include/single_phf.hpp
@@ -85,6 +85,10 @@ struct single_phf {
         return m_table_size;
     }
 
+    inline uint64_t seed() const {
+        return m_seed;
+    }
+
     template <typename Visitor>
     void visit(Visitor& visitor) {
         visitor.visit(m_seed);


### PR DESCRIPTION
This allows users to reimplement operator() by hashing themselves and then calling position(hash)