### PR TITLE
Add method partitioned_phf::position

### DIFF
--- a/include/partitioned_phf.hpp
+++ b/include/partitioned_phf.hpp
@@ -93,6 +93,10 @@ public:
     template <typename T>
     uint64_t operator()(T const& key) const {
         auto hash = Hasher::hash(key, m_seed);
+        return position(hash);
+    }
+
+    uint64_t position(typename Hasher::hash_type hash) const {
         auto b = m_bucketer.bucket(hash.mix());
         auto const& p = m_partitions[b];
         return p.offset + p.f.position(hash);


### PR DESCRIPTION
This mirrors single_phf::position and allows users to run the hasher themselves