### PR TITLE
Use universal visitors for const-ref saving

### DIFF
--- a/include/builders/internal_memory_builder_single_phf.hpp
+++ b/include/builders/internal_memory_builder_single_phf.hpp
@@ -175,14 +175,13 @@ struct internal_memory_builder_single_phf {
     }
 
     template <typename Visitor>
+    void visit(Visitor& visitor) const {
+        visit_impl(visitor, *this);
+    }
+
+    template <typename Visitor>
     void visit(Visitor& visitor) {
-        visitor.visit(m_seed);
-        visitor.visit(m_num_keys);
-        visitor.visit(m_num_buckets);
-        visitor.visit(m_table_size);
-        visitor.visit(m_bucketer);
-        visitor.visit(m_pilots);
-        visitor.visit(m_free_slots);
+        visit_impl(visitor, *this);
     }
 
     static uint64_t estimate_num_bytes_for_construction(uint64_t num_keys,
@@ -208,6 +207,17 @@ struct internal_memory_builder_single_phf {
     }
 
 private:
+    template <typename Visitor, typename T>
+    static void visit_impl(Visitor& visitor, T&& t) {
+        visitor.visit(t.m_seed);
+        visitor.visit(t.m_num_keys);
+        visitor.visit(t.m_num_buckets);
+        visitor.visit(t.m_table_size);
+        visitor.visit(t.m_bucketer);
+        visitor.visit(t.m_pilots);
+        visitor.visit(t.m_free_slots);
+    }
+
     uint64_t m_seed;
     uint64_t m_num_keys;
     uint64_t m_num_buckets;

--- a/include/encoders/bit_vector.hpp
+++ b/include/encoders/bit_vector.hpp
@@ -296,12 +296,22 @@ struct bit_vector {
     };
 
     template <typename Visitor>
+    void visit(Visitor& visitor) const {
+        visit_impl(visitor, *this);
+    }
+
+    template <typename Visitor>
     void visit(Visitor& visitor) {
-        visitor.visit(m_size);
-        visitor.visit(m_bits);
+        visit_impl(visitor, *this);
     }
 
 protected:
+    template <typename Visitor, typename T>
+    static void visit_impl(Visitor& visitor, T&& t) {
+        visitor.visit(t.m_size);
+        visitor.visit(t.m_bits);
+    }
+
     size_t m_size;
     std::vector<uint64_t> m_bits;
 };

--- a/include/encoders/compact_vector.hpp
+++ b/include/encoders/compact_vector.hpp
@@ -275,14 +275,23 @@ struct compact_vector {
     }
 
     template <typename Visitor>
+    void visit(Visitor& visitor) const {
+        visit_impl(visitor, *this);
+    }
+
+    template <typename Visitor>
     void visit(Visitor& visitor) {
-        visitor.visit(m_size);
-        visitor.visit(m_width);
-        visitor.visit(m_mask);
-        visitor.visit(m_bits);
+        visit_impl(visitor, *this);
     }
 
 private:
+    template <typename Visitor, typename T>
+    static void visit_impl(Visitor& visitor, T&& t) {
+        visitor.visit(t.m_size);
+        visitor.visit(t.m_width);
+        visitor.visit(t.m_mask);
+        visitor.visit(t.m_bits);
+    }
     uint64_t m_size;
     uint64_t m_width;
     uint64_t m_mask;

--- a/include/encoders/darray.hpp
+++ b/include/encoders/darray.hpp
@@ -86,14 +86,24 @@ struct darray {
     }
 
     template <typename Visitor>
+    void visit(Visitor& visitor) const {
+        visit_impl(visitor, *this);
+    }
+
+    template <typename Visitor>
     void visit(Visitor& visitor) {
-        visitor.visit(m_positions);
-        visitor.visit(m_block_inventory);
-        visitor.visit(m_subblock_inventory);
-        visitor.visit(m_overflow_positions);
+        visit_impl(visitor, *this);
     }
 
 protected:
+    template <typename Visitor, typename T>
+    static void visit_impl(Visitor& visitor, T&& t) {
+        visitor.visit(t.m_positions);
+        visitor.visit(t.m_block_inventory);
+        visitor.visit(t.m_subblock_inventory);
+        visitor.visit(t.m_overflow_positions);
+    }
+
     static void flush_cur_block(std::vector<uint64_t>& cur_block_positions,
                                 std::vector<int64_t>& block_inventory,
                                 std::vector<uint16_t>& subblock_inventory,

--- a/include/encoders/ef_sequence.hpp
+++ b/include/encoders/ef_sequence.hpp
@@ -80,13 +80,22 @@ struct ef_sequence {
     }
 
     template <typename Visitor>
+    void visit(Visitor& visitor) const {
+        visit_impl(visitor, *this);
+    }
+
+    template <typename Visitor>
     void visit(Visitor& visitor) {
-        visitor.visit(m_high_bits);
-        visitor.visit(m_high_bits_d1);
-        visitor.visit(m_low_bits);
+        visit_impl(visitor, *this);
     }
 
 private:
+    template <typename Visitor, typename T>
+    static void visit_impl(Visitor& visitor, T&& t) {
+        visitor.visit(t.m_high_bits);
+        visitor.visit(t.m_high_bits_d1);
+        visitor.visit(t.m_low_bits);
+    }
     bit_vector m_high_bits;
     darray1 m_high_bits_d1;
     compact_vector m_low_bits;

--- a/include/encoders/encoders.hpp
+++ b/include/encoders/encoders.hpp
@@ -33,6 +33,11 @@ struct compact {
     }
 
     template <typename Visitor>
+    void visit(Visitor& visitor) const {
+        visitor.visit(m_values);
+    }
+
+    template <typename Visitor>
     void visit(Visitor& visitor) {
         visitor.visit(m_values);
     }
@@ -98,13 +103,22 @@ struct partitioned_compact {
     }
 
     template <typename Visitor>
+    void visit(Visitor& visitor) const {
+        visit_impl(visitor, *this);
+    }
+
+    template <typename Visitor>
     void visit(Visitor& visitor) {
-        visitor.visit(m_size);
-        visitor.visit(m_bits_per_value);
-        visitor.visit(m_values);
+        visit_impl(visitor, *this);
     }
 
 private:
+    template <typename Visitor, typename T>
+    static void visit_impl(Visitor& visitor, T&& t) {
+        visitor.visit(t.m_size);
+        visitor.visit(t.m_bits_per_value);
+        visitor.visit(t.m_values);
+    }
     uint64_t m_size;
     std::vector<uint32_t> m_bits_per_value;
     bit_vector m_values;
@@ -170,12 +184,21 @@ struct dictionary {
     }
 
     template <typename Visitor>
+    void visit(Visitor& visitor) const {
+        visit_impl(visitor, *this);
+    }
+
+    template <typename Visitor>
     void visit(Visitor& visitor) {
-        visitor.visit(m_ranks);
-        visitor.visit(m_dict);
+        visit_impl(visitor, *this);
     }
 
 private:
+    template <typename Visitor, typename T>
+    static void visit_impl(Visitor& visitor, T&& t) {
+        visitor.visit(t.m_ranks);
+        visitor.visit(t.m_dict);
+    }
     compact_vector m_ranks;
     compact_vector m_dict;
 };
@@ -201,6 +224,11 @@ struct elias_fano {
     uint64_t access(uint64_t i) const {
         assert(i + 1 < m_values.size());
         return m_values.diff(i);
+    }
+
+    template <typename Visitor>
+    void visit(Visitor& visitor) const {
+        visitor.visit(m_values);
     }
 
     template <typename Visitor>
@@ -271,12 +299,22 @@ struct dual {
     }
 
     template <typename Visitor>
+    void visit(Visitor& visitor) const {
+        visit_impl(visitor, *this);
+    }
+
+    template <typename Visitor>
     void visit(Visitor& visitor) {
-        visitor.visit(m_front);
-        visitor.visit(m_back);
+        visit_impl(visitor, *this);
     }
 
 private:
+    template <typename Visitor, typename T>
+    static void visit_impl(Visitor& visitor, T&& t) {
+        visitor.visit(t.m_front);
+        visitor.visit(t.m_back);
+    }
+
     Front m_front;
     Back m_back;
 };

--- a/include/partitioned_phf.hpp
+++ b/include/partitioned_phf.hpp
@@ -13,13 +13,24 @@ struct partitioned_phf {
 private:
     struct partition {
         template <typename Visitor>
+        void visit(Visitor& visitor) const {
+            visit_impl(visitor, *this);
+        }
+
+        template <typename Visitor>
         void visit(Visitor& visitor) {
-            visitor.visit(offset);
-            visitor.visit(f);
+            visit_impl(visitor, *this);
         }
 
         uint64_t offset;
         single_phf<Hasher, Encoder, Minimal> f;
+
+    private:
+        template <typename Visitor, typename T>
+        static void visit_impl(Visitor& visitor, T&& t) {
+            visitor.visit(t.offset);
+            visitor.visit(t.f);
+        }
     };
 
 public:
@@ -138,15 +149,25 @@ public:
     }
 
     template <typename Visitor>
+    void visit(Visitor& visitor) const {
+        visit_impl(visitor, *this);
+    }
+
+    template <typename Visitor>
     void visit(Visitor& visitor) {
-        visitor.visit(m_seed);
-        visitor.visit(m_num_keys);
-        visitor.visit(m_table_size);
-        visitor.visit(m_bucketer);
-        visitor.visit(m_partitions);
+        visit_impl(visitor, *this);
     }
 
 private:
+    template <typename Visitor, typename T>
+    static void visit_impl(Visitor& visitor, T&& t) {
+        visitor.visit(t.m_seed);
+        visitor.visit(t.m_num_keys);
+        visitor.visit(t.m_table_size);
+        visitor.visit(t.m_bucketer);
+        visitor.visit(t.m_partitions);
+    }
+
     uint64_t m_seed;
     uint64_t m_num_keys;
     uint64_t m_table_size;

--- a/include/single_phf.hpp
+++ b/include/single_phf.hpp
@@ -97,17 +97,26 @@ struct single_phf {
     }
 
     template <typename Visitor>
+    void visit(Visitor& visitor) const {
+        visit_impl(visitor, *this);
+    }
+
+    template <typename Visitor>
     void visit(Visitor& visitor) {
-        visitor.visit(m_seed);
-        visitor.visit(m_num_keys);
-        visitor.visit(m_table_size);
-        visitor.visit(m_M);
-        visitor.visit(m_bucketer);
-        visitor.visit(m_pilots);
-        visitor.visit(m_free_slots);
+        visit_impl(visitor, *this);
     }
 
 private:
+    template <typename Visitor, typename T>
+    static void visit_impl(Visitor& visitor, T&& t) {
+        visitor.visit(t.m_seed);
+        visitor.visit(t.m_num_keys);
+        visitor.visit(t.m_table_size);
+        visitor.visit(t.m_M);
+        visitor.visit(t.m_bucketer);
+        visitor.visit(t.m_pilots);
+        visitor.visit(t.m_free_slots);
+    }
     uint64_t m_seed;
     uint64_t m_num_keys;
     uint64_t m_table_size;

--- a/include/utils/bucketers.hpp
+++ b/include/utils/bucketers.hpp
@@ -42,14 +42,24 @@ struct skew_bucketer {
     }
 
     template <typename Visitor>
+    void visit(Visitor& visitor) const {
+        visit_impl(visitor, *this);
+    }
+
+    template <typename Visitor>
     void visit(Visitor& visitor) {
-        visitor.visit(m_num_dense_buckets);
-        visitor.visit(m_num_sparse_buckets);
-        visitor.visit(m_M_num_dense_buckets);
-        visitor.visit(m_M_num_sparse_buckets);
+        visit_impl(visitor, *this);
     }
 
 private:
+    template <typename Visitor, typename T>
+    static void visit_impl(Visitor& visitor, T&& t) {
+        visitor.visit(t.m_num_dense_buckets);
+        visitor.visit(t.m_num_sparse_buckets);
+        visitor.visit(t.m_M_num_dense_buckets);
+        visitor.visit(t.m_M_num_sparse_buckets);
+    }
+
     uint64_t m_num_dense_buckets, m_num_sparse_buckets;
     __uint128_t m_M_num_dense_buckets, m_M_num_sparse_buckets;
 };
@@ -75,12 +85,21 @@ struct uniform_bucketer {
     }
 
     template <typename Visitor>
+    void visit(Visitor& visitor) const {
+        visit_impl(visitor, *this);
+    }
+
+    template <typename Visitor>
     void visit(Visitor& visitor) {
-        visitor.visit(m_num_buckets);
-        visitor.visit(m_M_num_buckets);
+        visit_impl(visitor, *this);
     }
 
 private:
+    template <typename Visitor, typename T>
+    static void visit_impl(Visitor& visitor, T&& t) {
+        visitor.visit(t.m_num_buckets);
+        visitor.visit(t.m_M_num_buckets);
+    }
     uint64_t m_num_buckets;
     __uint128_t m_M_num_buckets;
 };


### PR DESCRIPTION
If https://github.com/jermp/essentials/pull/9 is merged, visit functions would need to be implemented like this. This will allow to use const-ref instead of simple ref for saving, which is good and important for third-party users.

**Note**: Submodule essentials needs to be updated in the PR before actually merging this change.