### PR TITLE
Tweak cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,10 @@ MESSAGE(STATUS "CMAKE_BUILD_TYPE: " ${CMAKE_BUILD_TYPE})
 
 if(NOT TARGET PTHASH)
   add_library(PTHASH INTERFACE)
-  target_include_directories(PTHASH INTERFACE .)
+  target_include_directories(PTHASH INTERFACE include)
+  target_include_directories(PTHASH SYSTEM INTERFACE external/fastmod)
+  target_include_directories(PTHASH SYSTEM INTERFACE external/mm_file/include)
+  target_include_directories(PTHASH SYSTEM INTERFACE external/xxHash)
 
   target_compile_features(PTHASH INTERFACE cxx_std_17)
 
@@ -30,35 +33,28 @@ if(NOT TARGET PTHASH)
     target_compile_options(PTHASH INTERFACE -DPTHASH_ENABLE_LARGE_BUCKET_ID_TYPE)
   endif()
 
-  if (UNIX)
-    MESSAGE(STATUS "Compiling with flags: -std=c++17 -ggdb -pthread -Wall -Wextra -Wno-missing-braces -Wno-unknown-attributes -Wno-unused-function")
+  find_package(Threads REQUIRED)
+  target_link_libraries(PTHASH INTERFACE Threads::Threads)
 
-    target_compile_options(PTHASH INTERFACE -std=c++17)
-    target_compile_options(PTHASH INTERFACE -pthread)
-    target_compile_options(PTHASH INTERFACE -ggdb)
-    target_compile_options(PTHASH INTERFACE -Wall -Wextra -Wno-missing-braces -Wno-unknown-attributes -Wno-unused-function)
-
-    if (PTHASH_USE_SANITIZERS)
-      MESSAGE(STATUS "Using sanitizers. Compiling with flags: -fsanitize=address -fno-omit-frame-pointer")
-      target_compile_options(PTHASH INTERFACE -fsanitize=address -fno-omit-frame-pointer)
-    endif()
+  if (PTHASH_USE_SANITIZERS)
+    MESSAGE(STATUS "Using sanitizers. Compiling with flags: -fsanitize=address -fno-omit-frame-pointer")
+    target_compile_options(PTHASH INTERFACE -fsanitize=address -fno-omit-frame-pointer)
   endif()
 
   add_subdirectory(external/bits)
   target_link_libraries(PTHASH INTERFACE BITS)
-
-  target_include_directories(PTHASH SYSTEM INTERFACE external/xxHash)
 endif()
 
 # Only add benchmarks and tests when compiling PTHash itself, not when added as a dependency
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
-  target_compile_options(PTHASH INTERFACE -Werror)
+  target_compile_options(PTHASH INTERFACE -Werror -Wall -Wextra -Wno-missing-braces -Wno-unknown-attributes -Wno-unused-function -ggdb)
+  add_subdirectory(external/cmd_line_parser)
 
   add_executable(build src/build.cpp)
-  target_link_libraries(build PRIVATE PTHASH)
+  target_link_libraries(build PRIVATE PTHASH CMD_LINE_PARSER)
   add_executable(example src/example.cpp)
-  target_link_libraries(example PRIVATE PTHASH)
+  target_link_libraries(example PRIVATE PTHASH CMD_LINE_PARSER)
 
   file(GLOB TEST_SOURCES test/test_*.cpp)
   foreach(TEST_SRC ${TEST_SOURCES})

--- a/include/builders/external_memory_builder_partitioned_phf.hpp
+++ b/include/builders/external_memory_builder_partitioned_phf.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "include/builders/util.hpp"
-#include "external/mm_file/include/mm_file/mm_file.hpp"
-#include "include/builders/internal_memory_builder_single_phf.hpp"
-#include "include/builders/internal_memory_builder_partitioned_phf.hpp"
+#include "builders/util.hpp"
+#include "mm_file/mm_file.hpp"
+#include "builders/internal_memory_builder_single_phf.hpp"
+#include "builders/internal_memory_builder_partitioned_phf.hpp"
 
 namespace pthash {
 

--- a/include/builders/external_memory_builder_single_phf.hpp
+++ b/include/builders/external_memory_builder_single_phf.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "include/builders/util.hpp"
-#include "include/builders/search.hpp"
-#include "external/mm_file/include/mm_file/mm_file.hpp"
-#include "include/utils/bucketers.hpp"
-#include "include/utils/logger.hpp"
-#include "include/utils/hasher.hpp"
+#include "builders/util.hpp"
+#include "builders/search.hpp"
+#include "mm_file/mm_file.hpp"
+#include "utils/bucketers.hpp"
+#include "utils/logger.hpp"
+#include "utils/hasher.hpp"
 
 namespace pthash {
 

--- a/include/builders/internal_memory_builder_partitioned_phf.hpp
+++ b/include/builders/internal_memory_builder_partitioned_phf.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "include/builders/util.hpp"
-#include "include/builders/internal_memory_builder_single_phf.hpp"
+#include "builders/util.hpp"
+#include "builders/internal_memory_builder_single_phf.hpp"
 
 namespace pthash {
 

--- a/include/builders/internal_memory_builder_single_phf.hpp
+++ b/include/builders/internal_memory_builder_single_phf.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "include/builders/util.hpp"
-#include "include/builders/search.hpp"
-#include "include/utils/bucketers.hpp"
-#include "include/utils/logger.hpp"
-#include "include/utils/hasher.hpp"
+#include "builders/util.hpp"
+#include "builders/search.hpp"
+#include "utils/bucketers.hpp"
+#include "utils/logger.hpp"
+#include "utils/hasher.hpp"
 
 namespace pthash {
 

--- a/include/builders/search.hpp
+++ b/include/builders/search.hpp
@@ -5,10 +5,10 @@
 #include <atomic>   // for std::atomic
 #include <vector>
 
-#include "external/bits/include/bit_vector.hpp"
+#include "bit_vector.hpp"
 
-#include "include/builders/util.hpp"
-#include "include/utils/hasher.hpp"
+#include "builders/util.hpp"
+#include "utils/hasher.hpp"
 
 #include "search_xor.hpp"
 #include "search_add.hpp"

--- a/include/builders/util.hpp
+++ b/include/builders/util.hpp
@@ -4,7 +4,7 @@
 #include <thread>
 #include <cmath>  // for exp, log, lgamma
 
-#include "include/utils/logger.hpp"
+#include "utils/logger.hpp"
 
 namespace pthash {
 

--- a/include/partitioned_phf.hpp
+++ b/include/partitioned_phf.hpp
@@ -2,9 +2,9 @@
 
 #include <thread>
 
-#include "include/single_phf.hpp"
-#include "include/builders/internal_memory_builder_partitioned_phf.hpp"
-#include "include/builders/external_memory_builder_partitioned_phf.hpp"
+#include "single_phf.hpp"
+#include "builders/internal_memory_builder_partitioned_phf.hpp"
+#include "builders/external_memory_builder_partitioned_phf.hpp"
 
 namespace pthash {
 

--- a/include/pthash.hpp
+++ b/include/pthash.hpp
@@ -2,6 +2,6 @@
 
 #include "utils/encoders.hpp"
 #include "utils/dense_encoders.hpp"
-#include "include/single_phf.hpp"
-#include "include/partitioned_phf.hpp"
-#include "include/dense_partitioned_phf.hpp"
+#include "single_phf.hpp"
+#include "partitioned_phf.hpp"
+#include "dense_partitioned_phf.hpp"

--- a/include/single_phf.hpp
+++ b/include/single_phf.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "include/utils/bucketers.hpp"
-#include "include/builders/util.hpp"
-#include "include/builders/internal_memory_builder_single_phf.hpp"
-#include "include/builders/external_memory_builder_single_phf.hpp"
+#include "utils/bucketers.hpp"
+#include "builders/util.hpp"
+#include "builders/internal_memory_builder_single_phf.hpp"
+#include "builders/external_memory_builder_single_phf.hpp"
 
 namespace pthash {
 

--- a/include/utils/bucketers.hpp
+++ b/include/utils/bucketers.hpp
@@ -2,7 +2,7 @@
 
 #include <array>
 
-#include "include/utils/util.hpp"
+#include "utils/util.hpp"
 
 namespace pthash {
 

--- a/include/utils/encoders.hpp
+++ b/include/utils/encoders.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "util.hpp"
-#include "external/bits/include/compact_vector.hpp"
-#include "external/bits/include/elias_fano.hpp"
+#include "compact_vector.hpp"
+#include "elias_fano.hpp"
 
 #include <vector>
 #include <unordered_map>

--- a/include/utils/util.hpp
+++ b/include/utils/util.hpp
@@ -4,7 +4,7 @@
 #include <string>
 
 #include "essentials.hpp"
-#include "external/fastmod/fastmod.h"
+#include "fastmod.h"
 
 #define PTHASH_LIKELY(expr) __builtin_expect((bool)(expr), true)
 

--- a/src/build.cpp
+++ b/src/build.cpp
@@ -2,9 +2,9 @@
 #include <thread>
 #include <unordered_set>
 
-#include "external/cmd_line_parser/include/parser.hpp"
-#include "include/pthash.hpp"
-#include "src/util.hpp"
+#include "parser.hpp"
+#include "pthash.hpp"
+#include "util.hpp"
 
 using namespace pthash;
 

--- a/src/example.cpp
+++ b/src/example.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 
-#include "include/pthash.hpp"
-#include "src/util.hpp"
+#include "pthash.hpp"
+#include "util.hpp"
 
 int main() {
     using namespace pthash;

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -9,7 +9,7 @@
 #include <string>
 #include <vector>
 
-#include "include/utils/util.hpp"
+#include "utils/util.hpp"
 #include "essentials.hpp"
 
 namespace pthash {

--- a/test/common.hpp
+++ b/test/common.hpp
@@ -2,9 +2,9 @@
 
 #include <iostream>
 
-#include "include/pthash.hpp"
-#include "include/utils/util.hpp"
-#include "src/util.hpp"
+#include "pthash.hpp"
+#include "utils/util.hpp"
+#include "../src/util.hpp"
 
 namespace pthash::testing {
 


### PR DESCRIPTION
- When setting the include path to the main folder, projects depending on pthash would have stuff like `README.md` in their include paths. Also, using absolute paths (instead of include directories) causes problems when using pthash as a dependency, especially when running into diamond dependencies.
- Explicitly set compiler warnings only when compiling PTHash itself. Otherwise these get propagated to projects depending on it.
- With modern cmake, there is no need to specify "-pthread". Cmake does that for us if necessary and supported by the OS.