### PR TITLE
Upgrade external/bits to support cmake 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5...3.31)
+cmake_minimum_required(VERSION 3.5...4.0)
 project(PTHASH)
 
 if (NOT CMAKE_BUILD_TYPE)


### PR DESCRIPTION
Last PR in this series. This enables building projects depending on PTHash using cmake 4.0