### PR TITLE
Truncate existing temp file in meta_partition constructor

### DIFF
--- a/include/builders/external_memory_builder_partitioned_phf.hpp
+++ b/include/builders/external_memory_builder_partitioned_phf.hpp
@@ -281,7 +281,11 @@ private:
 
     struct meta_partition {
         meta_partition(std::string const& dir_name, uint64_t id)
-            : m_filename(dir_name + "/pthash.temp." + std::to_string(id)), m_size(0) {}
+            : m_filename(dir_name + "/pthash.temp." + std::to_string(id)), m_size(0) {
+            // Truncate the file if it exists from a previous run
+            std::ofstream truncate(m_filename.c_str(), std::ofstream::binary | std::ofstream::trunc);
+            truncate.close();
+        }
 
         void push_back(hash_type hash) {
             m_hashes.push_back(hash);


### PR DESCRIPTION
Ensure the temp file is truncated if it exists. Otherwise, repeated independent runs would add lines to the same file, and it isn't detected when the files are read later on, leading to "seed didn't work" exceptions.