### PR TITLE
feat: Support real time mapper in build a hash function

### DIFF
--- a/include/dense_partitioned_phf.hpp
+++ b/include/dense_partitioned_phf.hpp
@@ -23,6 +23,18 @@ struct dense_partitioned_phf  //
         return timings;
     }
 
+    template <typename Iterator, typename Mapper>
+    build_timings build_in_internal_memory(Iterator keys, const uint64_t num_keys,
+                                           build_configuration const& config,
+                                           Mapper const& mapper) {
+        build_configuration build_config = set_build_configuration(config);
+        internal_memory_builder_partitioned_phf<Hasher, Bucketer> builder;
+        key_mapping_iterator<Iterator, Mapper> mapped_keys(keys, mapper);
+        auto timings = builder.build_from_keys(mapped_keys, num_keys, build_config);
+        timings.encoding_microseconds = build(builder, build_config);
+        return timings;
+    }
+
     // template <typename Iterator>
     // build_timings build_in_external_memory(Iterator keys, const uint64_t num_keys,
     //                                        build_configuration const& config) {

--- a/include/partitioned_phf.hpp
+++ b/include/partitioned_phf.hpp
@@ -70,12 +70,36 @@ public:
         return timings;
     }
 
+    template <typename Iterator, typename Mapper>
+    build_timings build_in_internal_memory(Iterator keys, const uint64_t num_keys,
+                                           build_configuration const& config,
+                                           Mapper const& mapper) {
+        build_configuration build_config = set_build_configuration(config);
+        internal_memory_builder_partitioned_phf<Hasher, Bucketer> builder;
+        key_mapping_iterator<Iterator, Mapper> mapped_keys(keys, mapper);
+        auto timings = builder.build_from_keys(mapped_keys, num_keys, build_config);
+        timings.encoding_microseconds = build(builder, build_config);
+        return timings;
+    }
+
     template <typename Iterator>
     build_timings build_in_external_memory(Iterator keys, const uint64_t num_keys,
                                            build_configuration const& config) {
         build_configuration build_config = set_build_configuration(config);
         external_memory_builder_partitioned_phf<Hasher, Bucketer> builder;
         auto timings = builder.build_from_keys(keys, num_keys, build_config);
+        timings.encoding_microseconds = build(builder, build_config);
+        return timings;
+    }
+
+    template <typename Iterator, typename Mapper>
+    build_timings build_in_external_memory(Iterator keys, const uint64_t num_keys,
+                                           build_configuration const& config,
+                                           Mapper const& mapper) {
+        build_configuration build_config = set_build_configuration(config);
+        external_memory_builder_partitioned_phf<Hasher, Bucketer> builder;
+        key_mapping_iterator<Iterator, Mapper> mapped_keys(keys, mapper);
+        auto timings = builder.build_from_keys(mapped_keys, num_keys, build_config);
         timings.encoding_microseconds = build(builder, build_config);
         return timings;
     }

--- a/include/single_phf.hpp
+++ b/include/single_phf.hpp
@@ -4,6 +4,7 @@
 #include "builders/util.hpp"
 #include "builders/internal_memory_builder_single_phf.hpp"
 #include "builders/external_memory_builder_single_phf.hpp"
+#include "utils/util.hpp"
 
 namespace pthash {
 
@@ -25,6 +26,17 @@ struct single_phf  //
         timings.encoding_microseconds = build(builder, build_config);
         return timings;
     }
+    
+    template <typename Iterator, typename Mapper>
+    build_timings build_in_internal_memory(Iterator keys, const uint64_t num_keys,
+                                           build_configuration const& config, Mapper const& mapper) {
+        build_configuration build_config = set_build_configuration(config);
+        internal_memory_builder_single_phf<Hasher, Bucketer> builder;
+        key_mapping_iterator<Iterator, Mapper> mapped_keys(keys, mapper);
+        auto timings = builder.build_from_keys(mapped_keys, num_keys, build_config);
+        timings.encoding_microseconds = build(builder, build_config);
+        return timings;
+    }
 
     template <typename Iterator>
     build_timings build_in_external_memory(Iterator keys, const uint64_t num_keys,
@@ -32,6 +44,18 @@ struct single_phf  //
         build_configuration build_config = set_build_configuration(config);
         external_memory_builder_single_phf<Hasher, Bucketer> builder;
         auto timings = builder.build_from_keys(keys, num_keys, build_config);
+        timings.encoding_microseconds = build(builder, build_config);
+        return timings;
+    }
+
+    template <typename Iterator, typename Mapper>
+    build_timings build_in_external_memory(Iterator keys, const uint64_t num_keys,
+                                           build_configuration const& config,
+                                           Mapper const& mapper) {
+        build_configuration build_config = set_build_configuration(config);
+        external_memory_builder_single_phf<Hasher, Bucketer> builder;
+        key_mapping_iterator<Iterator, Mapper> mapped_keys(keys, mapper);
+        auto timings = builder.build_from_keys(mapped_keys, num_keys, build_config);
         timings.encoding_microseconds = build(builder, build_config);
         return timings;
     }

--- a/include/utils/util.hpp
+++ b/include/utils/util.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <chrono>
+#include <iterator>
 #include <string>
 
 #include "essentials.hpp"
@@ -56,5 +57,32 @@ template <typename DurationType>
 double to_microseconds(DurationType const& d) {
     return static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(d).count());
 }
+
+template <typename Iterator, typename Mapper>
+struct key_mapping_iterator {
+    using iterator_category = typename std::iterator_traits<Iterator>::iterator_category;
+    using value_type = typename std::iterator_traits<Iterator>::value_type;
+    using difference_type = typename std::iterator_traits<Iterator>::difference_type;
+    using pointer = typename std::iterator_traits<Iterator>::pointer;
+    using reference = typename std::iterator_traits<Iterator>::reference;
+
+    key_mapping_iterator(Iterator it, Mapper const& mapper) : m_it(it), m_mapper(&mapper) {}
+    inline auto operator*() const {
+        return (*m_mapper)(*m_it);
+    }
+    inline void operator++() {
+        ++m_it;
+    }
+    inline key_mapping_iterator operator+(uint64_t offset) const {
+        return key_mapping_iterator(m_it + offset, *m_mapper);
+    }
+    inline auto operator[](uint64_t offset) const {
+        return (*m_mapper)(m_it[offset]);
+    }
+
+private:
+    Iterator m_it;
+    Mapper const* m_mapper;
+};
 
 }  // namespace pthash


### PR DESCRIPTION
In some cases, the hash keys may occupy a lot of memory, so we do not want to store all of them. We create a new API to support a mapper function that we can use to calculate the keys using a resource with lower memory usage.